### PR TITLE
fixed typo

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -96,7 +96,7 @@ $ ./tomato-nvram.py
 102 settings written to set-nvram.sh
 ```
 
-**View/Edit** output `set-nvam.sh` to choose which settings to reapply.
+**View/Edit** output file `set-nvram.sh` to choose which settings to reapply.
 
 - - -
 


### PR DESCRIPTION
there was a character missing from the output file name
Not sure what happened at line 119. I think nano added a newline to the file
